### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ repositories {
 Then adding the dependency:
 
 ```groovy
-compile 'com.github.xmartlabs:RxSimpleNoSQL:-SNAPSHOT'
+implementation 'com.github.xmartlabs:RxSimpleNoSQL:-SNAPSHOT'
 ```
 
 RxSimpleNoSQL requires at minimum Java 7 or Android 2.2.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ repositories {
 Then adding the dependency:
 
 ```groovy
-implementation 'com.github.xmartlabs:RxSimpleNoSQL:-SNAPSHOT'
+api 'com.github.xmartlabs:RxSimpleNoSQL:-SNAPSHOT'
 ```
 
 RxSimpleNoSQL requires at minimum Java 7 or Android 2.2.


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.